### PR TITLE
Add locale filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ While running the command you can pass two extra options
   You do not need to remove all directies and files if you switch from the longer (slugified) names to only id's. The script will smartly rename everything. Isn't that neat :)?
 - ```ruby zendesk-helpcenter-export.rb ... --verbose-logging``` to help you debugging when something is not going as planned
 
+- ```ruby zendesk-helpcenter-export.rb ... --filter-locales locales``` allow to export data for specified locales only
+
 # Requirements
 
 - ruby >= 2.0, do ```ruby -v``` in your terminal. If lower google how update. (easy with rvm, rbenv, brew)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ While running the command you can pass two extra options
   You do not need to remove all directies and files if you switch from the longer (slugified) names to only id's. The script will smartly rename everything. Isn't that neat :)?
 - ```ruby zendesk-helpcenter-export.rb ... --verbose-logging``` to help you debugging when something is not going as planned
 
-- ```ruby zendesk-helpcenter-export.rb ... --filter-locales locales``` allow to export data for specified locales only
-
 # Requirements
 
 - ruby >= 2.0, do ```ruby -v``` in your terminal. If lower google how update. (easy with rvm, rbenv, brew)

--- a/zendesk-helpcenter-export.rb
+++ b/zendesk-helpcenter-export.rb
@@ -51,7 +51,7 @@ class ExportHelpCenter
   include HTTParty
 
 
-  attr :raw_data, :log_level, :output_type
+  attr :raw_data, :log_level, :output_type, :locale_filter
   LOG_LEVELS = {standard: 1, verbose: 2}
   OUTPUT_TYPES = [:slugified, :id_only]
   REQUIRED_INPUTS = [:email, :password, :subdomain]
@@ -63,6 +63,7 @@ class ExportHelpCenter
     @auth = {username: options[:email], password: options[:password]}
     @log_level = options[:log_level]
     @output_type = options[:output_type]
+    @locale_filter = options[:locale]
     # used to make one big dumpfile of all metadata related to your helpcenter
     @raw_data = {locales: [], categories: [], sections: [], articles: [], article_attachments: []}
     # configure Httparty base uri
@@ -73,7 +74,10 @@ class ExportHelpCenter
   # ---------------------------------------
 
   def to_html!
-    locales["locales"].each do |locale_code|
+    locales = get_locales(@locale_filter);
+    log("These locales will be exported: #{locales}", :verbose);
+
+    locales.each do |locale_code|
       # contrary to what is said on https://developer.zendesk.com/rest_api/docs/core/locales
       # we do not get an ID, so I'm inventing one that is unique per locale
       locale = {"name" => locale_code, "id" => locale_code.chars.map {|ch| ch.ord - 'A'.ord + 10}.join}
@@ -311,6 +315,28 @@ class ExportHelpCenter
       log("      !!! failed download: " + article_attachment['content_url'] + ". error: #{e.message}")
     end
   end
+
+  # Retrieve the list of locales to export
+  # ---------------------------------------
+  # input:
+  # - locale_filter: user filter
+  # output:
+  # - an array containing locales on 2 (fr) or 5 chars (en-us)
+  def get_locales(locale_filter)
+    all_locales = locales()['locales']
+    
+    return all_locales if locale_filter.nil?
+
+    locales_to_filter = locale_filter.split(',')
+    existing_locales = locales_to_filter & all_locales
+    non_existing_locales = locales_to_filter - all_locales
+
+    log("Locales #{non_existing_locales} won't be exported as they do not exist for specified account", :verbose) unless non_existing_locales.empty?
+
+    return existing_locales unless existing_locales.empty?
+
+    raise RuntimeError, "Locales #{locale_filter} does not exist in specified account"
+  end
 end
 
 # section: Executing the script
@@ -332,6 +358,7 @@ OptionParser.new do |opts|
   opts.on('-d', '--subdomain subdomain', 'Zendesk subdomain (e.g. icecream)')  { |subdomain|  options[:subdomain] = subdomain}
   opts.on('-v', '--verbose-logging', 'Verbose logging to identify possible bugs')     { options[:log_level] = :verbose }
   opts.on('-c', '--compact-file-names', 'Force short filenames for windows based file systems that are limited to 260 path lengths') { options[:output_type] = :id_only }
+  opts.on('-l', '--filter-locales locales', 'Locales to filter, comma separated list (e.g. fr for single locale filter, de,it,ch for multiple locales)') { |locale| options[:locale] = locale }
   opts.on('-h', '--help', 'Displays Help') { puts opts; exit }
 end.parse!
 

--- a/zendesk-helpcenter-export.rb
+++ b/zendesk-helpcenter-export.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 require 'httparty'
-require 'FileUtils'
+require 'fileutils'
 require 'json'
 require 'uri'
 require 'optparse'


### PR DESCRIPTION
Adds a "--locale-filter" ("-l") option to the command line. It allows to filter locales that will be exported.

Example:

One locale:
$ ruby zendesk-helpcenter-export.rb -e email -p password -d subdomain -l sv
Multiple locales:
$ ruby zendesk-helpcenter-export.rb -e email -p password -d subdomain -l sv,de,it,fr
