### PR TITLE
TOC per folder , localize internal-links, and attachments independent of article.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#  Ruby script to export your Zendesk helpcenter (v 0.2)
+#  Ruby script to export your Zendesk helpcenter
 
 Script based on https://github.com/skipjac/pull-zendesk-forums
 (which exports the forum, not the help center article)
@@ -6,15 +6,17 @@ Script based on https://github.com/skipjac/pull-zendesk-forums
 it uses the Zendesk API to export all categories, sections, articles, article_attachments to html (and json)
 all of this in a nested folder structure
 
-    - category
-      - section
-        - article
-          - article.html
-          - image-1.jpg
-          - image-2.png
-    meta_data.json
+    - <category>/
+      - index.html
+      - <section>/
+        - index.html
+        - <article>/
+          - index.html
+    - attachments/
+      - image-1.jpg
+      - image-2.png
+    - meta_data.json
 
-![Zendesk demo](https://github.com/pjmuller/zendesk-helpcenter-export/raw/master/demo-screenshot.png)
 Bonus: it is smart in that when you rename a category, section, article it won't
 start to create duplicate folders but renames the old ones.
 The script can thus be used for both a new dump as updating an existing one.

--- a/zendesk-helpcenter-export.rb
+++ b/zendesk-helpcenter-export.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rubygems'
 require 'httparty'
 require 'fileutils'
@@ -110,6 +111,9 @@ class ExportHelpCenter
 
   def create_table_of_contents!
     File.open("./index.html", "w+") { |f| f.puts main_overview_file }
+    
+    # ここで各階層の index.html を生成すれば良い。
+    
   end
 
   # Section: Article content
@@ -120,6 +124,9 @@ class ExportHelpCenter
     # and replace all image links towards the local url
     regex_find = /https:\/\/.+?zendesk.com.+?article_attachments\/(\d+?)\/(.+)\.(.+?)" alt/
     regex_replace = output_type == :slugified ? '\1-\2.\3" alt' : '\1.\3" alt'
+    
+    # ここでコンテンツを加工できる。
+    
     boiler_plate_html do
       """
       <h1>#{article['name']}</h1>

--- a/zendesk-helpcenter-export.rb
+++ b/zendesk-helpcenter-export.rb
@@ -393,6 +393,7 @@ class ExportHelpCenter
   # ---------------------------------------
   def api(url)
     begin
+      sleep(1)
       options = {:basic_auth => @auth}
       self.class.get("/api/v2/help_center/#{url}", options)
     rescue => e
@@ -441,6 +442,7 @@ class ExportHelpCenter
     log(" - - - - #{article_attachment['file_name']}")
 
     begin
+      sleep(1)
       options = {:basic_auth => @auth}
       file_contents = self.class.get(article_attachment['content_url'], options)
       file_path = "#{store_in_dir}#{file_name}"


### PR DESCRIPTION
It may be just a one-time script, but helps me a lot.

Here is my modification, if you like :

1. TOC for each categories, sections ( not only for entire subdomain ).
1. Enabling internal-links among articles ( article A ⇔ article B ).
1. Moving the attachments outside of the section/article folder, because the same attachment (img) can be placed in different articles.